### PR TITLE
Added Custom Stream RTMP Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ docker run -it -p 80:80 -p 1935:1935 \
   --env "MULTISTREAMING_KEY_TWITCH=__your_twitch_stream_key__" \
   --env "MULTISTREAMING_KEY_FACEBOOK=__your_facebook_stream_key__" \
   --env "MULTISTREAMING_KEY_YOUTUBE=__your_youtube_stream_key__" \  
+  --env "MULTISTREAMING_KEY_CUSTOM=__your_full_rtmp_url__" \ 
   multistreaming-server:latest
 ```
 
@@ -28,6 +29,7 @@ Note that several environment variables are set:
 * `MULTISTREAMING_KEY_TWITCH` _(OPTIONAL)_ - Your Twitch stream key. Only define if you want to rebroadcast your stream to Twitch.
 * `MULTISTREAMING_KEY_FACEBOOK` _(OPTIONAL)_ - Your Facebook stream key. Only define if you want to rebroadcast your stream to Facebook.
 * `MULTISTREAMING_KEY_YOUTUBE` _(OPTIONAL)_ - Your YouTube stream key. Only define if you want to rebroadcast your stream to YouTube.
+* `MULTISTREAMING_KEY_CUSTOM` _(OPTIONAL)_ - Your full RTMP url, including rtmp://, to any live stream service. Only define if you want to rebroadcast your stream to a custom service.
 
 You could start this docker with no stream keys defined, but that wouldn't do anything interesting then.
 

--- a/multistreaming-server/launch-nginx-server.sh
+++ b/multistreaming-server/launch-nginx-server.sh
@@ -21,6 +21,11 @@ if [[ -v MULTISTREAMING_KEY_YOUTUBE ]]; then
 	sed -e "s/##PUSH_YOUTUBE_MARKER##//g" -i /usr/local/nginx/conf/nginx.conf
 fi
 
+if [[ -v MULTISTREAMING_KEY_CUSTOM ]]; then
+	envsubst < nginx-conf-custom.txt >>  /usr/local/nginx/conf/nginx.conf
+	sed -e "s/##PUSH_CUSTOM_MARKER##//g" -i /usr/local/nginx/conf/nginx.conf
+fi
+
 envsubst < nginx-conf-suffix.txt >>  /usr/local/nginx/conf/nginx.conf
 
 # finally, launch nginx

--- a/multistreaming-server/nginx-conf/nginx-conf-custom.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-custom.txt
@@ -1,0 +1,12 @@
+		# Custom RTMP Application
+		application custom {
+			live on;
+			record off;
+
+			# Only allow localhost to publish
+			allow publish 127.0.0.1;
+			deny publish all;
+
+			# Push URL with the Custom stream Ingest URL
+			push ${MULTISTREAMING_KEY_CUSTOM};
+		}

--- a/multistreaming-server/nginx-conf/nginx-conf-facebook.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-facebook.txt
@@ -1,4 +1,4 @@
-		# Facebook Stream Application  
+		# Facebook Stream Application
 		application facebook {
 			live on;
 			record off;
@@ -7,8 +7,7 @@
 			allow publish 127.0.0.1;
 			deny publish all;
 
-			# Push URL with the Facebook stream key. We are using stunnel to 
+			# Push URL with the Facebook stream key. We are using stunnel to
 			# push to a secure stream.
 			push rtmp://127.0.0.1:19350/rtmp/${MULTISTREAMING_KEY_FACEBOOK};
 		}
-

--- a/multistreaming-server/nginx-conf/nginx-conf-prefix.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-prefix.txt
@@ -110,7 +110,7 @@ http {
     #}
 
 }
- 
+
 rtmp {
 	server {
 		listen 1935;
@@ -124,8 +124,8 @@ rtmp {
 			record_path /var/www/html/recordings;
 			record_unique on;
 			# Define the applications to which the stream will be pushed, comment them out to disable the ones not needed:
-##PUSH_TWITCH_MARKER##			push rtmp://localhost/twitch;
-##PUSH_FACEBOOK_MARKER##			push rtmp://localhost/facebook;
-##PUSH_YOUTUBE_MARKER##			push rtmp://localhost/youtube;
+##PUSH_TWITCH_MARKER##   push rtmp://localhost/twitch;
+##PUSH_FACEBOOK_MARKER##   push rtmp://localhost/facebook;
+##PUSH_YOUTUBE_MARKER##   push rtmp://localhost/youtube;
+##PUSH_CUSTOM_MARKER##   push rtmp://localhost/custom;
 		}
-

--- a/multistreaming-server/nginx-conf/nginx-conf-twitch.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-twitch.txt
@@ -10,4 +10,3 @@
 			# Push URL with the Twitch stream key
 			push rtmp://live-cdg.twitch.tv/app/${MULTISTREAMING_KEY_TWITCH};
 		}
-

--- a/multistreaming-server/nginx-conf/nginx-conf-youtube.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-youtube.txt
@@ -1,4 +1,4 @@
-		# YouTube Stream Application  
+		# YouTube Stream Application
 		application youtube {
 			live on;
 			record off;
@@ -10,4 +10,3 @@
 			# Push URL with the YouTube stream key
 			push rtmp://a.rtmp.youtube.com/live2/${MULTISTREAMING_KEY_YOUTUBE};
 		}
-


### PR DESCRIPTION
I added the ability to pass an environment variable for 'MULTISTREAMING_KEY_CUSTOM' where you paste in the whole RTMP url. I did this for adding Microsoft Stream functionality. I have not gotten it to work with Microsoft Stream yet, however, I did test the MULTISTREAMING_KEY_CUSTOM functionality by passing in an entire Youtube RTMP url with the stream key and it worked properly. 