### PR TITLE
Added Support for Periscope

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ docker run -it -p 80:80 -p 1935:1935 \
   --env "MULTISTREAMING_KEY_FACEBOOK=__your_facebook_stream_key__" \
   --env "MULTISTREAMING_KEY_YOUTUBE=__your_youtube_stream_key__" \  
   --env "MULTISTREAMING_KEY_CUSTOM=__your_full_rtmp_url__" \ 
+  --env "MULTISTREAMING_KEY_PERISCOPE=__your_periscope_stream_key__" \
+  --env "PERISCOPE_REGION_ID=__periscope_2-letter_region_code__" \
   multistreaming-server:latest
 ```
 
@@ -32,6 +34,8 @@ Note that several environment variables are set when running the Docker image:
 * `MULTISTREAMING_KEY_FACEBOOK` _(OPTIONAL)_ - Your Facebook stream key. Only define if you want to rebroadcast your stream to Facebook.
 * `MULTISTREAMING_KEY_YOUTUBE` _(OPTIONAL)_ - Your YouTube stream key. Only define if you want to rebroadcast your stream to YouTube.
 * `MULTISTREAMING_KEY_CUSTOM` _(OPTIONAL)_ - Your full RTMP url, including rtmp://, to any live stream service. Only define if you want to rebroadcast your stream to a custom service.
+* `MULTISTREAMING_KEY_PERISCOPE` _(OPTIONAL)_ - Your Periscope sream key. Only define if you want to rebroadcast your stream to Periscope.
+* `PERISCOPE_REGION_ID` _(OPTIONAL)_ - The two letter region code that is part of the Periscope server URL. If undefined, it will default to `ca` (the "US West" region)
 
 You could start this docker with no stream keys defined, but that wouldn't do anything interesting then.
 

--- a/multistreaming-server/Dockerfile
+++ b/multistreaming-server/Dockerfile
@@ -6,8 +6,6 @@ ARG RTMP_REPO=defanator
 ARG RTMP_MODULE_VERSION=fix-build-with-gcc8
 
 RUN set -x \
- && addgroup -g 82 -S www-data \
- && adduser -u 82 -D -S -G www-data www-data \
  && addgroup -S stunnel \
  && adduser -S -D -H -h /dev/null -s /sbin/nologin -G stunnel -g stunnel stunnel \
  && echo "http://dl-3.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories \
@@ -26,7 +24,7 @@ RUN set -x \
  && apk del build-deps \
  && mkdir -p /var/www/html/recordings \
  && mkdir -p /var/run/stunnel/ \
- && chown www-data:www-data -R /var/www/html \
+ && chown nobody:nobody -R /var/www/html \
  && chown stunnel:stunnel /var/run/stunnel/
 
 COPY index.html /usr/local/nginx/html/
@@ -41,6 +39,7 @@ RUN ln -sf /dev/stdout /usr/local/nginx/logs/access.log
 RUN ln -sf /dev/stderr /usr/local/nginx/logs/error.log
 
 RUN cp /nginx-rtmp-module-${RTMP_MODULE_VERSION}/stat.xsl /usr/local/nginx/html/
+
 EXPOSE 1935
 EXPOSE 80
 

--- a/multistreaming-server/Dockerfile
+++ b/multistreaming-server/Dockerfile
@@ -36,6 +36,11 @@ COPY stunnel-conf/etc-default-stunnel /etc/default/stunnel
 COPY stunnel-conf/etc-stunnel-conf.d-fb.conf /etc/stunnel/conf.d/fb.conf
 COPY stunnel-conf/etc-stunnel-stunnel.conf /etc/stunnel/stunnel.conf
 
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /usr/local/nginx/logs/access.log
+RUN ln -sf /dev/stderr /usr/local/nginx/logs/error.log
+
+RUN cp /nginx-rtmp-module-${RTMP_MODULE_VERSION}/stat.xsl /usr/local/nginx/html/
 EXPOSE 1935
 EXPOSE 80
 

--- a/multistreaming-server/launch-nginx-server.sh
+++ b/multistreaming-server/launch-nginx-server.sh
@@ -21,6 +21,15 @@ if [ $MULTISTREAMING_KEY_YOUTUBE ]; then
 	sed -e "s/##PUSH_YOUTUBE_MARKER##//g" -i /usr/local/nginx/conf/nginx.conf
 fi
 
+if [ $MULTISTREAMING_KEY_PERISCOPE ]; then
+	if [ !$PERISCOPE_REGION_ID ]; then
+		export PERISCOPE_REGION_ID='ca'
+	fi
+	envsubst < nginx-conf-periscope.txt >>  /usr/local/nginx/conf/nginx.conf
+	sed -e "s/##PUSH_PERISCOPE_MARKER##//g" -i /usr/local/nginx/conf/nginx.conf
+fi
+
+
 if [ $MULTISTREAMING_KEY_CUSTOM ]; then
 	envsubst < nginx-conf-custom.txt >>  /usr/local/nginx/conf/nginx.conf
 	sed -e "s/##PUSH_CUSTOM_MARKER##//g" -i /usr/local/nginx/conf/nginx.conf

--- a/multistreaming-server/nginx-conf/nginx-conf-periscope.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-periscope.txt
@@ -9,10 +9,9 @@
 
 			# need to transcode Periscope since it is particular about video and audio
 			exec ffmpeg -re -i rtmp://localhost:1935/${DOLLAR}app/${DOLLAR}name 
-						-c:v libx264 -s 1280x720 -b:v 2500k -bufsize 1M -r 30 -x264opts "keyint=90:min-keyint=90:no-scenecut"
-						-c:a aac -b:a 128k
-						-f flv rtmp://localhost:1935/periscope/${DOLLAR}{name};
-
+				-c:v libx264 -s 1280x720 -b:v 2500k -bufsize 1M -r 30 -x264opts "keyint=90:min-keyint=90:no-scenecut"
+				-c:a aac -b:a 128k
+				-f flv rtmp://localhost:1935/periscope/${DOLLAR}{name};
 		}
 
 		application periscope {

--- a/multistreaming-server/nginx-conf/nginx-conf-periscope.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-periscope.txt
@@ -8,10 +8,10 @@
 			deny publish all;
 
 			# need to transcode Periscope since it is particular about video and audio
-            exec ffmpeg -re -i rtmp://localhost:1935/${DOLLAR}app/${DOLLAR}name 
-            				-c:v libx264 -s 1280x720 -b:v 2500k -bufsize 1M -r 30 -x264opts "keyint=90:min-keyint=90:no-scenecut"
-            				-c:a aac -b:a 128k
-                        -f flv rtmp://localhost:1935/periscope/${DOLLAR}{name};
+			exec ffmpeg -re -i rtmp://localhost:1935/${DOLLAR}app/${DOLLAR}name 
+						-c:v libx264 -s 1280x720 -b:v 2500k -bufsize 1M -r 30 -x264opts "keyint=90:min-keyint=90:no-scenecut"
+						-c:a aac -b:a 128k
+						-f flv rtmp://localhost:1935/periscope/${DOLLAR}{name};
 
 		}
 

--- a/multistreaming-server/nginx-conf/nginx-conf-periscope.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-periscope.txt
@@ -1,0 +1,28 @@
+		# Periscope Stream Application
+		application periscope_transcode {
+			live on;
+			record off;
+
+			# Only allow localhost to publish
+			allow publish 127.0.0.1;
+			deny publish all;
+
+			# need to transcode Periscope since it is particular about video and audio
+            exec ffmpeg -re -i rtmp://localhost:1935/${DOLLAR}app/${DOLLAR}name 
+            				-c:v libx264 -s 1280x720 -b:v 2500k -bufsize 1M -r 30 -x264opts "keyint=90:min-keyint=90:no-scenecut"
+            				-c:a aac -b:a 128k
+                        -f flv rtmp://localhost:1935/periscope/${DOLLAR}{name};
+
+		}
+
+		application periscope {
+			live on;
+			record off;
+
+			# Only allow localhost to publish
+			allow publish 127.0.0.1;
+			deny publish all;
+
+			# Push URL with the Twitch stream key
+			push rtmp://${PERISCOPE_REGION_ID}.pscp.tv:80/x/${MULTISTREAMING_KEY_PERISCOPE};
+		}

--- a/multistreaming-server/nginx-conf/nginx-conf-prefix.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-prefix.txt
@@ -42,6 +42,23 @@ http {
 			return 401;
 		}
 
+        # This URL provides RTMP statistics in XML
+        location /stat {
+            rtmp_stat all;
+
+            # Use this stylesheet to view XML as web page
+            # in browser
+            rtmp_stat_stylesheet stat.xsl;
+        }
+
+        location /stat.xsl {
+            # XML stylesheet to view RTMP stats.
+            # Copy stat.xsl wherever you want
+            # and put the full directory path here
+            root /usr/local/nginx/html/;
+        }
+
+
         #error_page  404              /404.html;
 
         # redirect server error pages to the static page /50x.html

--- a/multistreaming-server/nginx-conf/nginx-conf-prefix.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-prefix.txt
@@ -145,4 +145,5 @@ rtmp {
 ##PUSH_FACEBOOK_MARKER##   push rtmp://localhost/facebook;
 ##PUSH_YOUTUBE_MARKER##   push rtmp://localhost/youtube;
 ##PUSH_CUSTOM_MARKER##   push rtmp://localhost/custom;
+##PUSH_PERISCOPE_MARKER##   push rtmp://localhost/periscope_transcode;
 		}


### PR DESCRIPTION
This adds support for Periscope. The challenge with Periscope is that they are very particular with the stream format. So for Periscope rebroadcasting, the stream is piped through `ffmpeg` first to transcode it to what Periscope wants. 