### PR TITLE
Instagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Multi-Service RTMP Broadcaster
 
-The goal of this project is to create a Docker-deployed service that will allow you to easily broadcast a livestream to multiple services (YouTube, Twitch, Facebook, etc) at the same time. This stream rebroadcaster is designed to be used by a single source / user. 
+The goal of this project is to create a Docker-deployed service that will allow you to easily broadcast a livestream to multiple services (YouTube, Twitch, Facebook, etc) at the same time. This stream rebroadcaster is designed to be used by a single source / user.
 
 ## Usage
 The instructions here assume you are running on linux. With some modification of the commands, you can make this Docker build work on Windows and Mac OS too.
@@ -18,25 +18,27 @@ docker run -it -p 80:80 -p 1935:1935 \
   --env MULTISTREAMING_PASSWORD=__made_up_password__ \
   --env "MULTISTREAMING_KEY_TWITCH=__your_twitch_stream_key__" \
   --env "MULTISTREAMING_KEY_FACEBOOK=__your_facebook_stream_key__" \
+  --env "MULTISTREAMING_KEY_INSTAGRAM=__your_instagram_stream_key_from_yellow_duck__" \
   --env "MULTISTREAMING_KEY_YOUTUBE=__your_youtube_stream_key__" \  
-  --env "MULTISTREAMING_KEY_MICROSOFTSTREAM=__your_microsoft_stream_ingest_url__" \ 
-  --env "MULTISTREAMING_KEY_CUSTOM=__your_full_rtmp_url__" \ 
+  --env "MULTISTREAMING_KEY_MICROSOFTSTREAM=__your_microsoft_stream_ingest_url__" \
+  --env "MULTISTREAMING_KEY_CUSTOM=__your_full_rtmp_url__" \
   --env "MULTISTREAMING_KEY_PERISCOPE=__your_periscope_stream_key__" \
   --env "PERISCOPE_REGION_ID=__periscope_2-letter_region_code__" \
   multistreaming-server:latest
 ```
 
-Alternatively, you could use the DockerHub build of this image by pulling and using the `kamprath/multistreaming-server:latest` Docker image. 
+Alternatively, you could use the DockerHub build of this image by pulling and using the `kamprath/multistreaming-server:latest` Docker image.
 
 Note that several environment variables are set when running the Docker image:
 
-* `MULTISTREAMING_PASSWORD` _(REQUIRED)_ - This is a password you define and will be used by your steaming software. This is a marginally secure way to prevent other people from pushing to your stream. 
+* `MULTISTREAMING_PASSWORD` _(REQUIRED)_ - This is a password you define and will be used by your steaming software. This is a marginally secure way to prevent other people from pushing to your stream.
 * `MULTISTREAMING_KEY_TWITCH` _(OPTIONAL)_ - Your Twitch stream key. Only define if you want to rebroadcast your stream to Twitch.
 * `MULTISTREAMING_KEY_FACEBOOK` _(OPTIONAL)_ - Your Facebook stream key. Only define if you want to rebroadcast your stream to Facebook.
+* `MULTISTREAMING_KEY_INSTAGRAM` _(OPTIONAL)_ - Your Instagram stream key. You will need to use https://yellowduck.tv/ to retrieve your stream key for Instagram. Only define if you want to rebroadcast your stream to Instagram.
 * `MULTISTREAMING_KEY_YOUTUBE` _(OPTIONAL)_ - Your YouTube stream key. Only define if you want to rebroadcast your stream to YouTube.
 * `MULTISTREAMING_KEY_MICROSOFTSTREAM` _(OPTIONAL)_ - Your Microsoft Stream Ingest URL. Only define if you want to rebroadcast your stream to Microsoft Stream.
 * `MULTISTREAMING_KEY_CUSTOM` _(OPTIONAL)_ - Your full RTMP url, including rtmp://, to any live stream service. Only define if you want to rebroadcast your stream to a custom service.
-* `MULTISTREAMING_KEY_PERISCOPE` _(OPTIONAL)_ - Your Periscope sream key. Only define if you want to rebroadcast your stream to Periscope.
+* `MULTISTREAMING_KEY_PERISCOPE` _(OPTIONAL)_ - Your Periscope stream key. Only define if you want to rebroadcast your stream to Periscope.
 * `PERISCOPE_REGION_ID` _(OPTIONAL)_ - The two letter region code that is part of the Periscope server URL. If undefined, it will default to `ca` (the "US West" region)
 
 You could start this docker with no stream keys defined, but that wouldn't do anything interesting then.

--- a/multistreaming-server/Dockerfile
+++ b/multistreaming-server/Dockerfile
@@ -32,6 +32,7 @@ COPY nginx-conf/nginx-conf-*.txt /
 COPY launch-nginx-server.sh launch-nginx-server.sh
 COPY stunnel-conf/etc-default-stunnel /etc/default/stunnel
 COPY stunnel-conf/etc-stunnel-conf.d-fb.conf /etc/stunnel/conf.d/fb.conf
+COPY stunnel-conf/etc-stunnel-conf.d-ig.conf /etc/stunnel/conf.d/ig.conf
 COPY stunnel-conf/etc-stunnel-stunnel.conf /etc/stunnel/stunnel.conf
 
 # forward request and error logs to docker log collector

--- a/multistreaming-server/launch-nginx-server.sh
+++ b/multistreaming-server/launch-nginx-server.sh
@@ -37,7 +37,7 @@ fi
 if [ $MULTISTREAMING_KEY_MICROSOFTSTREAM ]; then
 	export MICROSOFTSTREAMRTMP=${MULTISTREAMING_KEY_MICROSOFTSTREAM%/live/*}
 	export MICROSOFTSTREAMAPPNAME=live/${MULTISTREAMING_KEY_MICROSOFTSTREAM#*/live/}
-	envsubst \${MICROSOFTSTREAMRTMP},\${MICROSOFTSTREAMAPPNAME} < nginx-conf-microsoftstream.txt >>  /usr/local/nginx/conf/nginx.conf
+	envsubst < nginx-conf-microsoftstream.txt >>  /usr/local/nginx/conf/nginx.conf
 	sed -e "s/##PUSH_MICROSOFTSTREAM_MARKER##//g" -i /usr/local/nginx/conf/nginx.conf
 fi
 

--- a/multistreaming-server/launch-nginx-server.sh
+++ b/multistreaming-server/launch-nginx-server.sh
@@ -11,6 +11,12 @@ if [ $MULTISTREAMING_KEY_FACEBOOK ]; then
 	/usr/bin/stunnel &
 fi
 
+if [ $MULTISTREAMING_KEY_INSTAGRAM ]; then
+	envsubst < nginx-conf-instagram.txt >>  /usr/local/nginx/conf/nginx.conf
+	sed -e "s/##PUSH_INSTAGRAM_MARKER##//g" -i /usr/local/nginx/conf/nginx.conf
+	/usr/bin/stunnel &
+fi
+
 if [ $MULTISTREAMING_KEY_TWITCH ]; then
 	envsubst < nginx-conf-twitch.txt >>  /usr/local/nginx/conf/nginx.conf
 	sed -e "s/##PUSH_TWITCH_MARKER##//g" -i /usr/local/nginx/conf/nginx.conf

--- a/multistreaming-server/nginx-conf/nginx-conf-instagram.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-instagram.txt
@@ -1,0 +1,13 @@
+		# Instagram Stream Application using Yellow Duck TV
+		application instagram {
+			live on;
+			record off;
+
+			#Only allow localhost to publish
+			allow publish 127.0.0.1;
+			deny publish all;
+
+			# Push URL with the Instagram stream key. We are using stunnel to
+			# push to a secure stream.
+			push rtmp://127.0.0.1:19351/rtmp/${MULTISTREAMING_KEY_INSTAGRAM};
+		}

--- a/multistreaming-server/nginx-conf/nginx-conf-prefix.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-prefix.txt
@@ -143,9 +143,9 @@ rtmp {
 			# Define the applications to which the stream will be pushed, comment them out to disable the ones not needed:
 ##PUSH_TWITCH_MARKER##   push rtmp://localhost/twitch;
 ##PUSH_FACEBOOK_MARKER##   push rtmp://localhost/facebook;
+##PUSH_INSTAGRAM_MARKER##   push rtmp://localhost/instagram;
 ##PUSH_YOUTUBE_MARKER##   push rtmp://localhost/youtube;
 ##PUSH_CUSTOM_MARKER##   push rtmp://localhost/custom;
 ##PUSH_PERISCOPE_MARKER##   push rtmp://localhost/periscope_transcode;
 ##PUSH_MICROSOFTSTREAM_MARKER##   push rtmp://localhost/microsoftstream;
-
 		}

--- a/multistreaming-server/stunnel-conf/etc-stunnel-conf.d-ig.conf
+++ b/multistreaming-server/stunnel-conf/etc-stunnel-conf.d-ig.conf
@@ -1,0 +1,5 @@
+[fb-live]
+client = yes
+accept = 127.0.0.1:19351
+connect = live-upload.instagram.com:443
+verifyChain = no

--- a/multistreaming-server/stunnel-conf/etc-stunnel-conf.d-ig.conf
+++ b/multistreaming-server/stunnel-conf/etc-stunnel-conf.d-ig.conf
@@ -1,4 +1,4 @@
-[fb-live]
+[ig-live]
 client = yes
 accept = 127.0.0.1:19351
 connect = live-upload.instagram.com:443


### PR DESCRIPTION
Added the ability to stream to Instagram. Please note that Instagram doesn't technically support streaming from OBS or third party applications. However, you can download this application https://yellowduck.tv/ and sign in with Instagram. It initiates the Live Broadcast functionality on Instagram and provides you with the stream key. You can then paste in the stream key with `MULTISTREAMING_KEY_INSTAGRAM`. It will use Stunnel to initiate the connection.