### PR TITLE
Update rtmp module uizaio

### DIFF
--- a/multistreaming-server/Dockerfile
+++ b/multistreaming-server/Dockerfile
@@ -21,7 +21,7 @@ RUN set -x \
  && export CFLAGS=-Wno-error \
  && ./configure --with-http_ssl_module --add-module=../nginx-rtmp-module-${RTMP_MODULE_VERSION} \
  && make \
- && make install\
+ && make install \
  && apk del build-deps \
  && mkdir -p /var/www/html/recordings \
  && mkdir -p /var/run/stunnel/ \

--- a/multistreaming-server/Dockerfile
+++ b/multistreaming-server/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3
 MAINTAINER Michael Kamprath "https://github.com/michaelkamprath"
 
 ARG NGINX_VERSION=1.17.9
-ARG RTMP_REPO=defanator
-ARG RTMP_MODULE_VERSION=fix-build-with-gcc8
+ARG RTMP_REPO=uizaio
+ARG RTMP_MODULE_VERSION=1.4.0.4
 
 RUN set -x \
  && addgroup -S stunnel \
@@ -18,6 +18,7 @@ RUN set -x \
  && wget -O nginx-rtmp-module-${RTMP_MODULE_VERSION}.tar.gz https://github.com/${RTMP_REPO}/nginx-rtmp-module/archive/${RTMP_MODULE_VERSION}.tar.gz \
  && tar -zxvf nginx-rtmp-module-${RTMP_MODULE_VERSION}.tar.gz \
  && cd nginx-${NGINX_VERSION} \
+ && export CFLAGS=-Wno-error \
  && ./configure --with-http_ssl_module --add-module=../nginx-rtmp-module-${RTMP_MODULE_VERSION} \
  && make \
  && make install\

--- a/multistreaming-server/nginx-conf/nginx-conf-periscope.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-periscope.txt
@@ -8,10 +8,10 @@
 			deny publish all;
 
 			# need to transcode Periscope since it is particular about video and audio
-			exec ffmpeg -re -i rtmp://localhost:1935/${DOLLAR}app/${DOLLAR}name 
+			exec ffmpeg -re -i rtmp://localhost:1935/${DOLLAR}app/${DOLLAR}name
 				-c:v libx264 -s 1280x720 -b:v 2500k -bufsize 1M -r 30 -x264opts "keyint=90:min-keyint=90:no-scenecut"
 				-c:a aac -b:a 128k
-				-f flv rtmp://localhost:1935/periscope/${DOLLAR}{name};
+				-f flv rtmp://localhost:1935/periscope/${DOLLAR}name;
 		}
 
 		application periscope {


### PR DESCRIPTION
Updating to the [Uizaio fork](https://github.com/uizaio/nginx-rtmp-module) of the RTMP module since it appears to be the latest supported version.