### PR TITLE
Added ability to transcode Facebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Multi-Service RTMP Broadcaster
 
-The goal of this project is to create a Docker-deployed service that will allow you to easily broadcast a livestream to multiple services (YouTube, Twitch, Facebook, etc) at the same time. This stream rebroadcaster is designed to be used by a single source / user.
+The goal of this project is to create a Docker-deployed service that will allow you to easily broadcast a live stream to multiple services (YouTube, Twitch, Facebook, etc) at the same time. This stream rebroadcaster is designed to be used by a single source / user.
 
 ## Usage
-The instructions here assume you are running on linux. With some modification of the commands, you can make this Docker build work on Windows and Mac OS too.
+The instructions here assume you are running on Linux. With some modification of the commands, you can make this Docker build work on Windows and Mac OS too.
 
 The first step is to build the docker file. After you clone this repository, `cd` into and and issue:
 
@@ -34,16 +34,17 @@ Note that several environment variables are set when running the Docker image:
 * `MULTISTREAMING_PASSWORD` _(REQUIRED)_ - This is a password you define and will be used by your steaming software. This is a marginally secure way to prevent other people from pushing to your stream.
 * `MULTISTREAMING_KEY_TWITCH` _(OPTIONAL)_ - Your Twitch stream key. Only define if you want to rebroadcast your stream to Twitch.
 * `MULTISTREAMING_KEY_FACEBOOK` _(OPTIONAL)_ - Your Facebook stream key. Only define if you want to rebroadcast your stream to Facebook.
+* `FACEBOOK_TRANSCODE` _(OPTIONAL)_ - Define and set to 1 if you want to transcode the stream sent to Facebook to it's recommended maximum of 1280x720 @ 4500 Kbps. Not required to stream to Facebook, but if you are streaming above the recommended maximum, Facebook will complain.
 * `MULTISTREAMING_KEY_INSTAGRAM` _(OPTIONAL)_ - Your Instagram stream key. You will need to use https://yellowduck.tv/ to retrieve your stream key for Instagram. Only define if you want to rebroadcast your stream to Instagram.
 * `MULTISTREAMING_KEY_YOUTUBE` _(OPTIONAL)_ - Your YouTube stream key. Only define if you want to rebroadcast your stream to YouTube.
 * `MULTISTREAMING_KEY_MICROSOFTSTREAM` _(OPTIONAL)_ - Your Microsoft Stream Ingest URL. Only define if you want to rebroadcast your stream to Microsoft Stream.
-* `MULTISTREAMING_KEY_CUSTOM` _(OPTIONAL)_ - Your full RTMP url, including rtmp://, to any live stream service. Only define if you want to rebroadcast your stream to a custom service.
+* `MULTISTREAMING_KEY_CUSTOM` _(OPTIONAL)_ - Your full RTMP URL, including rtmp://, to any live stream service. Only define if you want to rebroadcast your stream to a custom service.
 * `MULTISTREAMING_KEY_PERISCOPE` _(OPTIONAL)_ - Your Periscope stream key. Only define if you want to rebroadcast your stream to Periscope.
 * `PERISCOPE_REGION_ID` _(OPTIONAL)_ - The two letter region code that is part of the Periscope server URL. If undefined, it will default to `ca` (the "US West" region)
 
-You could start this docker with no stream keys defined, but that wouldn't do anything interesting then.
+You could start this docker with no stream keys defined, but that wouldn't do anything interesting then. Note that if your configuration requires transcoding (Facebook or Periscope), then you might get poor bit rates if your CPU isn't up to the job. It is recommended that your modern CPU has at least 4 cores for each transcoding task you enable.
 
-Once the Docker image is running, set up your stream software with the following paramters:
+Once the Docker image is running, set up your stream software with the following parameters:
 
 * **Server** : `rtmp://__docker_host_IP_address__/live` - Replace `__docker_host_IP_address__` with the IP address of your host that is running this Docker container.
 * **Stream Key** : `__made_up_stream_name__?pwd=__made_up_password__` - Here `__made_up_stream_name__` is any arbitrary stream name, and `__made_up_password__` is the same password defined for `MULTISTREAMING_PASSWORD` above.

--- a/multistreaming-server/Dockerfile
+++ b/multistreaming-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM jrottenberg/ffmpeg:4.2-alpine
 MAINTAINER Michael Kamprath "https://github.com/michaelkamprath"
 
 ARG NGINX_VERSION=1.17.9
@@ -11,7 +11,7 @@ RUN set -x \
  && echo "http://dl-3.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories \
  && apk update \
  && apk add --no-cache --update stunnel ca-certificates \
- && apk add --no-cache pcre openssl ffmpeg stunnel gettext \
+ && apk add --no-cache pcre openssl stunnel gettext \
  && apk add --no-cache --virtual build-deps build-base pcre-dev openssl-dev zlib zlib-dev wget make \
  && wget -O nginx-${NGINX_VERSION}.tar.gz http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
  && tar -zxvf nginx-${NGINX_VERSION}.tar.gz \
@@ -46,5 +46,8 @@ EXPOSE 1935
 EXPOSE 80
 
 STOPSIGNAL SIGTERM
+
+# Remove the entry point from jrottenberg/ffmpeg
+ENTRYPOINT []
 
 CMD ["/bin/sh", "/launch-nginx-server.sh"]

--- a/multistreaming-server/launch-nginx-server.sh
+++ b/multistreaming-server/launch-nginx-server.sh
@@ -7,7 +7,11 @@ envsubst < nginx-conf-prefix.txt >  /usr/local/nginx/conf/nginx.conf
 
 if [ $MULTISTREAMING_KEY_FACEBOOK ]; then
 	envsubst < nginx-conf-facebook.txt >>  /usr/local/nginx/conf/nginx.conf
-	sed -e "s/##PUSH_FACEBOOK_MARKER##//g" -i /usr/local/nginx/conf/nginx.conf
+	if [ $FACEBOOK_TRANSCODE ]; then
+		sed -e "s/##PUSH_FACEBOOK_TRANSCODE_MARKER##//g" -i /usr/local/nginx/conf/nginx.conf
+	else
+		sed -e "s/##PUSH_FACEBOOK_MARKER##//g" -i /usr/local/nginx/conf/nginx.conf
+	fi
 	/usr/bin/stunnel &
 fi
 

--- a/multistreaming-server/nginx-conf/nginx-conf-facebook.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-facebook.txt
@@ -11,3 +11,19 @@
 			# push to a secure stream.
 			push rtmp://127.0.0.1:19350/rtmp/${MULTISTREAMING_KEY_FACEBOOK};
 		}
+
+		# Transcode Facebook Stream Application
+		application facebook_transcode {
+			live on;
+			record off;
+
+			# Only allow localhost to publish
+			allow publish 127.0.0.1;
+			deny publish all;
+
+			# Facebook only accepts a 1280x720 stream. Transcode to that dimension.
+			exec ffmpeg -re -i rtmp://localhost:1935/${DOLLAR}app/${DOLLAR}name
+				-c:v libx264 -s 1280x720 -b:v 4500k -bufsize 12M -r 30 -x264opts "keyint=60:min-keyint=60:no-scenecut:nal-hrd=cbr"
+				-c:a copy
+				-f flv rtmp://localhost:1935/facebook/${DOLLAR}name;
+		}

--- a/multistreaming-server/nginx-conf/nginx-conf-periscope.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-periscope.txt
@@ -9,8 +9,8 @@
 
 			# need to transcode Periscope since it is particular about video and audio
 			exec ffmpeg -re -i rtmp://localhost:1935/${DOLLAR}app/${DOLLAR}name
-				-c:v libx264 -s 1280x720 -b:v 2500k -bufsize 1M -r 30 -x264opts "keyint=90:min-keyint=90:no-scenecut"
-				-c:a aac -b:a 128k
+				-c:v libx264 -s 1280x720 -b:v 2500k -bufsize 12M -r 30 -x264opts "keyint=90:min-keyint=90:no-scenecut:nal-hrd=cbr"
+				-c:a aac -b:a 128k -ar 44100
 				-f flv rtmp://localhost:1935/periscope/${DOLLAR}name;
 		}
 

--- a/multistreaming-server/nginx-conf/nginx-conf-periscope.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-periscope.txt
@@ -9,8 +9,8 @@
 
 			# need to transcode Periscope since it is particular about video and audio
 			exec ffmpeg -re -i rtmp://localhost:1935/${DOLLAR}app/${DOLLAR}name
-				-c:v libx264 -s 1280x720 -b:v 2500k -bufsize 12M -r 30 -x264opts "keyint=90:min-keyint=90:no-scenecut:nal-hrd=cbr"
-				-c:a aac -b:a 128k -ar 44100
+				-c:v libx264 -s 1280x720 -b:v 3500k -bufsize 12M -r 30 -x264opts "keyint=90:min-keyint=90:no-scenecut:nal-hrd=cbr"
+				-c:a libfdk_aac -b:a 128k -ar 44100
 				-f flv rtmp://localhost:1935/periscope/${DOLLAR}name;
 		}
 

--- a/multistreaming-server/nginx-conf/nginx-conf-prefix.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-prefix.txt
@@ -143,6 +143,7 @@ rtmp {
 			# Define the applications to which the stream will be pushed, comment them out to disable the ones not needed:
 ##PUSH_TWITCH_MARKER##   push rtmp://localhost/twitch;
 ##PUSH_FACEBOOK_MARKER##   push rtmp://localhost/facebook;
+##PUSH_FACEBOOK_TRANSCODE_MARKER##   push rtmp://localhost/facebook_transcode;
 ##PUSH_INSTAGRAM_MARKER##   push rtmp://localhost/instagram;
 ##PUSH_YOUTUBE_MARKER##   push rtmp://localhost/youtube;
 ##PUSH_CUSTOM_MARKER##   push rtmp://localhost/custom;


### PR DESCRIPTION
Facebook Live doesn't want to receive live streams over 720P @ 4500 Kbps, 30 FPS. If you are pushing 1080P for YouTube Live and Twitch, the rebroadcast to Facebook Live needs to be transcoded first. This PR adds the optional ability to transcode the stream to 720P before pushing to Facebook. This transcoding is optional and should only be used if you are pushing above 720P. 

Also fixed the transcoding configuration for Periscope, and migrated the Docker image towards using `jrottenberg/ffmpeg:4.2-alpine` as the base in order to get a version of `ffmpeg` that enables the `libfdk_aac` audio codec.

Closes #11 