### PR TITLE
Add support for streaming audio only to Icecast servers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ docker run -it -p 80:80 -p 1935:1935 \
   --env "MULTISTREAMING_KEY_CUSTOM=__your_full_rtmp_url__" \
   --env "MULTISTREAMING_KEY_PERISCOPE=__your_periscope_stream_key__" \
   --env "PERISCOPE_REGION_ID=__periscope_2-letter_region_code__" \
+  --env "MULTISTREAMING_ICECAST=__your_icecast_url__" \
   multistreaming-server:latest
 ```
 
@@ -41,6 +42,7 @@ Note that several environment variables are set when running the Docker image:
 * `MULTISTREAMING_KEY_CUSTOM` _(OPTIONAL)_ - Your full RTMP URL, including rtmp://, to any live stream service. Only define if you want to rebroadcast your stream to a custom service.
 * `MULTISTREAMING_KEY_PERISCOPE` _(OPTIONAL)_ - Your Periscope stream key. Only define if you want to rebroadcast your stream to Periscope.
 * `PERISCOPE_REGION_ID` _(OPTIONAL)_ - The two letter region code that is part of the Periscope server URL. If undefined, it will default to `ca` (the "US West" region)
+* `MULTISTREAMING_ICECAST` _(OPTIONAL)_ - Your full Icecast URL, including icecast://, username, password and mount point. For example: icecast://source:password@icecast-hostname:8000/stream
 
 You could start this docker with no stream keys defined, but that wouldn't do anything interesting then. Note that if your configuration requires transcoding (Facebook or Periscope), then you might get poor bit rates if your CPU isn't up to the job. It is recommended that your modern CPU has at least 4 cores for each transcoding task you enable.
 

--- a/multistreaming-server/launch-nginx-server.sh
+++ b/multistreaming-server/launch-nginx-server.sh
@@ -51,6 +51,11 @@ if [ $MULTISTREAMING_KEY_MICROSOFTSTREAM ]; then
 	sed -e "s/##PUSH_MICROSOFTSTREAM_MARKER##//g" -i /usr/local/nginx/conf/nginx.conf
 fi
 
+if [ $MULTISTREAMING_ICECAST ]; then
+	envsubst < nginx-conf-icecast.txt >>  /usr/local/nginx/conf/nginx.conf
+	sed -e "s/##PUSH_ICECAST_MARKER##//g" -i /usr/local/nginx/conf/nginx.conf
+fi
+
 envsubst < nginx-conf-suffix.txt >>  /usr/local/nginx/conf/nginx.conf
 
 # finally, launch nginx

--- a/multistreaming-server/nginx-conf/nginx-conf-icecast.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-icecast.txt
@@ -7,5 +7,5 @@
 			allow publish 127.0.0.1;
 			deny publish all;
 
-			exec ffmpeg -re -i rtmp://localhost:1935/${DOLLAR}app/${DOLLAR}name	-c:a libmp3lame -b:a 192k -content_type 'audio/mpeg' -vn -f mp3 ${MULTISTREAMING_ICECAST};
+			exec ffmpeg -re -vn -i rtmp://localhost:1935/${DOLLAR}app/${DOLLAR}name -c:a copy -content_type audio/aac -f adts ${MULTISTREAMING_ICECAST};
 		}

--- a/multistreaming-server/nginx-conf/nginx-conf-icecast.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-icecast.txt
@@ -1,0 +1,11 @@
+		# Transcode Icecast Stream Application
+		application icecast {
+			live on;
+			record off;
+
+			# Only allow localhost to publish
+			allow publish 127.0.0.1;
+			deny publish all;
+
+			exec ffmpeg -re -i rtmp://localhost:1935/${DOLLAR}app/${DOLLAR}name	-c:a libmp3lame -b:a 192k -content_type 'audio/mpeg' -vn -f mp3 ${MULTISTREAMING_ICECAST};
+		}

--- a/multistreaming-server/nginx-conf/nginx-conf-prefix.txt
+++ b/multistreaming-server/nginx-conf/nginx-conf-prefix.txt
@@ -149,4 +149,5 @@ rtmp {
 ##PUSH_CUSTOM_MARKER##   push rtmp://localhost/custom;
 ##PUSH_PERISCOPE_MARKER##   push rtmp://localhost/periscope_transcode;
 ##PUSH_MICROSOFTSTREAM_MARKER##   push rtmp://localhost/microsoftstream;
+##PUSH_ICECAST_MARKER##   push rtmp://localhost/icecast;
 		}


### PR DESCRIPTION
Note: Quality is currently hardcoded to 192 kbps MP3, can add environment variables for bitrate and format if this is preferred.